### PR TITLE
Move TimeArbitraries to an arb package

### DIFF
--- a/modules/testkit/src/main/scala/io/chrisdavenport/cats/time/arb/TimeArbitraries.scala
+++ b/modules/testkit/src/main/scala/io/chrisdavenport/cats/time/arb/TimeArbitraries.scala
@@ -3,16 +3,9 @@ package io.chrisdavenport.cats.time.arb
 import java.time._
 
 import org.scalacheck.{Arbitrary, Gen, Cogen}
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
 
 trait TimeArbitraries {
-
-  implicit def functionArbitrary[B, A: Arbitrary]: Arbitrary[B => A] =
-    Arbitrary {
-      for {
-        a <- Arbitrary.arbitrary[A]
-      } yield { (_: B) => a }
-    }
 
   implicit val arbitraryZoneId: Arbitrary[ZoneId] = Arbitrary {
     import scala.jdk.CollectionConverters._

--- a/modules/testkit/src/main/scala/io/chrisdavenport/cats/time/arb/TimeArbitraries.scala
+++ b/modules/testkit/src/main/scala/io/chrisdavenport/cats/time/arb/TimeArbitraries.scala
@@ -1,9 +1,9 @@
-package io.chrisdavenport.cats.time.instances
+package io.chrisdavenport.cats.time.arb
 
 import java.time._
 
 import org.scalacheck.{Arbitrary, Gen, Cogen}
-import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Arbitrary._
 
 trait TimeArbitraries {
 

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/DurationTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/DurationTests.scala
@@ -4,9 +4,9 @@ import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
 import cats.kernel.laws.discipline.CommutativeMonoidTests
-import TimeArbitraries._
 import java.time.Duration
 import io.chrisdavenport.cats.time.instances.duration._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class DurationTests extends CatsSuite {
   checkAll("Duration", HashTests[Duration].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/InstantTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/InstantTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.Instant
 import io.chrisdavenport.cats.time.instances.instant._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class InstantTests extends CatsSuite {
   checkAll("Instant", HashTests[Instant].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalDateTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalDateTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.LocalDate
 import io.chrisdavenport.cats.time.instances.localdate._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class LocalDateTests extends CatsSuite {
   checkAll("LocalDate", HashTests[LocalDate].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalDateTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalDateTimeTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.LocalDateTime
 import io.chrisdavenport.cats.time.instances.localdatetime._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class LocalDateTimeTests extends CatsSuite {
   checkAll("LocalDateTime", HashTests[LocalDateTime].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalTimeTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.LocalTime
 import io.chrisdavenport.cats.time.instances.localtime._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class LocalTimeTests extends CatsSuite {
   checkAll("LocalTime", HashTests[LocalTime].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/MonthDayTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/MonthDayTests.scala
@@ -5,7 +5,7 @@ import java.time.MonthDay
 import cats.kernel.laws.discipline.{ HashTests, OrderTests }
 import cats.tests.CatsSuite
 import io.chrisdavenport.cats.time.instances.monthday._
-import TimeArbitraries._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class MonthDayTests extends CatsSuite {
   checkAll("MonthDay", HashTests[MonthDay].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/MonthTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/MonthTests.scala
@@ -4,7 +4,7 @@ import java.time.Month
 
 import cats.kernel.laws.discipline.{ HashTests, OrderTests }
 import cats.tests.CatsSuite
-import io.chrisdavenport.cats.time.instances.TimeArbitraries._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 import io.chrisdavenport.cats.time.instances.month._
 
 class MonthTests extends CatsSuite {

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetDateTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetDateTimeTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.OffsetDateTime
 import io.chrisdavenport.cats.time.instances.offsetdatetime._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class OffsetDateTimeTests extends CatsSuite {
   checkAll("OffsetDateTime", HashTests[OffsetDateTime].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetTimeTests.scala
@@ -6,7 +6,6 @@ import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
 import java.time.OffsetTime
 import io.chrisdavenport.cats.time.instances.offsettime._
-import io.chrisdavenport.cats.time.instances.instant._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class OffsetTimeTests extends CatsSuite {

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetTimeTests.scala
@@ -4,9 +4,10 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.OffsetTime
 import io.chrisdavenport.cats.time.instances.offsettime._
+import io.chrisdavenport.cats.time.instances.instant._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class OffsetTimeTests extends CatsSuite {
   checkAll("OffsetTime", HashTests[OffsetTime].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/YearMonthTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/YearMonthTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.YearMonth
 import io.chrisdavenport.cats.time.instances.yearmonth._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class YearMonthTests extends CatsSuite {
   checkAll("YearMonth", HashTests[YearMonth].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/YearTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/YearTests.scala
@@ -3,9 +3,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.Year
 import io.chrisdavenport.cats.time.instances.year._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class YearTests extends CatsSuite {
   checkAll("Year", HashTests[Year].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneIdTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneIdTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.EqTests
-import TimeArbitraries._
 import java.time.ZoneId
 import io.chrisdavenport.cats.time.instances.zoneid._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class ZoneIdTests extends CatsSuite {
   checkAll("ZoneId", EqTests[ZoneId].eqv)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneOffsetTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneOffsetTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.ZoneOffset
 import io.chrisdavenport.cats.time.instances.zoneoffset._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class ZoneOffsetTests extends CatsSuite {
   checkAll("ZoneOffset", HashTests[ZoneOffset].hash)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZonedDateTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZonedDateTimeTests.scala
@@ -4,9 +4,9 @@ package io.chrisdavenport.cats.time.instances
 import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import TimeArbitraries._
 import java.time.ZonedDateTime
 import io.chrisdavenport.cats.time.instances.zoneddatetime._
+import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 
 class ZonedDateTimeTests extends CatsSuite {
   checkAll("ZonedDateTime", HashTests[ZonedDateTime].hash)


### PR DESCRIPTION
I think `TimeArbitraries` shouldn't be in the `instances` package