### PR TITLE
Use `MUnit` in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,7 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("3.1.0", "2.12.15", "2.13.6"),
   libraryDependencies ++= Seq(
     "org.typelevel"          %%% "cats-core"               % "2.6.1",
+    "org.typelevel"          %%% "cats-laws"               % "2.6.1" % Test,
     "org.typelevel"          %%% "discipline-munit"        % "1.0.9" % Test,
     "org.scala-lang.modules" %%% "scala-collection-compat" % "2.5.0" % Test,
   )

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     name := "cats-time"
   )
   .jsSettings(
-    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.3.0"
+    libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.3.0",
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
   )
 
 lazy val tests = crossProject(JSPlatform, JVMPlatform)
@@ -28,6 +29,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "cats-time-tests",
   )
+  .jsSettings(scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))
 
 lazy val testKit = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
@@ -40,6 +42,7 @@ lazy val testKit = crossProject(JSPlatform, JVMPlatform)
       "org.scala-lang.modules" %%% "scala-collection-compat" % "2.5.0",
     )
   )
+  .jsSettings(scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)))
 
 lazy val docs = project
   .in(file("modules/docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,6 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("3.1.0", "2.12.15", "2.13.6"),
   libraryDependencies ++= Seq(
     "org.typelevel"          %%% "cats-core"               % "2.6.1",
-    "org.typelevel"          %%% "cats-testkit-scalatest"  % "2.1.5" % Test,
     "org.typelevel"          %%% "discipline-munit"        % "1.0.9" % Test,
     "org.scala-lang.modules" %%% "scala-collection-compat" % "2.5.0" % Test,
   )

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel"          %%% "cats-core"               % "2.6.1",
     "org.typelevel"          %%% "cats-testkit-scalatest"  % "2.1.5" % Test,
+    "org.typelevel"          %%% "discipline-munit"        % "1.0.9" % Test,
     "org.scala-lang.modules" %%% "scala-collection-compat" % "2.5.0" % Test,
   )
 )

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/DurationTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/DurationTests.scala
@@ -1,14 +1,14 @@
 package io.chrisdavenport.cats.time.instances
 
-import cats.tests.CatsSuite
+import cats.kernel.laws.discipline.CommutativeMonoidTests
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import cats.kernel.laws.discipline.CommutativeMonoidTests
-import java.time.Duration
-import io.chrisdavenport.cats.time.instances.duration._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.duration._
+import java.time.Duration
+import munit.DisciplineSuite
 
-class DurationTests extends CatsSuite {
+class DurationTests extends DisciplineSuite {
   checkAll("Duration", HashTests[Duration].hash)
   checkAll("Duration", OrderTests[Duration].order)
   checkAll("Duration", CommutativeMonoidTests[Duration].commutativeMonoid)

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/InstantTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/InstantTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.Instant
-import io.chrisdavenport.cats.time.instances.instant._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.instant._
+import java.time.Instant
+import munit.DisciplineSuite
 
-class InstantTests extends CatsSuite {
+class InstantTests extends DisciplineSuite {
   checkAll("Instant", HashTests[Instant].hash)
   checkAll("Instant", OrderTests[Instant].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalDateTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalDateTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.LocalDate
-import io.chrisdavenport.cats.time.instances.localdate._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.localdate._
+import java.time.LocalDate
+import munit.DisciplineSuite
 
-class LocalDateTests extends CatsSuite {
+class LocalDateTests extends DisciplineSuite {
   checkAll("LocalDate", HashTests[LocalDate].hash)
   checkAll("LocalDate", OrderTests[LocalDate].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalDateTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalDateTimeTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.LocalDateTime
-import io.chrisdavenport.cats.time.instances.localdatetime._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.localdatetime._
+import java.time.LocalDateTime
+import munit.DisciplineSuite
 
-class LocalDateTimeTests extends CatsSuite {
+class LocalDateTimeTests extends DisciplineSuite {
   checkAll("LocalDateTime", HashTests[LocalDateTime].hash)
   checkAll("LocalDateTime", OrderTests[LocalDateTime].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/LocalTimeTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.LocalTime
-import io.chrisdavenport.cats.time.instances.localtime._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.localtime._
+import java.time.LocalTime
+import munit.DisciplineSuite
 
-class LocalTimeTests extends CatsSuite {
+class LocalTimeTests extends DisciplineSuite {
   checkAll("LocalTime", HashTests[LocalTime].hash)
   checkAll("LocalTime", OrderTests[LocalTime].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/MonthDayTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/MonthDayTests.scala
@@ -3,11 +3,11 @@ package io.chrisdavenport.cats.time.instances
 import java.time.MonthDay
 
 import cats.kernel.laws.discipline.{ HashTests, OrderTests }
-import cats.tests.CatsSuite
-import io.chrisdavenport.cats.time.instances.monthday._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.monthday._
+import munit.DisciplineSuite
 
-class MonthDayTests extends CatsSuite {
+class MonthDayTests extends DisciplineSuite {
   checkAll("MonthDay", HashTests[MonthDay].hash)
   checkAll("MonthDay", OrderTests[MonthDay].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/MonthTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/MonthTests.scala
@@ -3,11 +3,11 @@ package io.chrisdavenport.cats.time.instances
 import java.time.Month
 
 import cats.kernel.laws.discipline.{ HashTests, OrderTests }
-import cats.tests.CatsSuite
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
 import io.chrisdavenport.cats.time.instances.month._
+import munit.DisciplineSuite
 
-class MonthTests extends CatsSuite {
+class MonthTests extends DisciplineSuite {
   checkAll("Month", HashTests[Month].hash)
   checkAll("Month", OrderTests[Month].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetDateTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetDateTimeTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.OffsetDateTime
-import io.chrisdavenport.cats.time.instances.offsetdatetime._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.offsetdatetime._
+import java.time.OffsetDateTime
+import munit.DisciplineSuite
 
-class OffsetDateTimeTests extends CatsSuite {
+class OffsetDateTimeTests extends DisciplineSuite {
   checkAll("OffsetDateTime", HashTests[OffsetDateTime].hash)
   checkAll("OffsetDateTime", OrderTests[OffsetDateTime].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/OffsetTimeTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.OffsetTime
-import io.chrisdavenport.cats.time.instances.offsettime._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.offsettime._
+import java.time.OffsetTime
+import munit.DisciplineSuite
 
-class OffsetTimeTests extends CatsSuite {
+class OffsetTimeTests extends DisciplineSuite {
   checkAll("OffsetTime", HashTests[OffsetTime].hash)
   checkAll("OffsetTime", OrderTests[OffsetTime].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/PeriodTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/PeriodTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
+import munit.DisciplineSuite
 // import cats.kernel.laws.discipline.HashTests
 // import cats.kernel.laws.discipline.OrderTests
 // import TimeArbitraries._
 // import java.time.Period
 // import io.chrisdavenport.cats.time.instances.hashWithOrder._
 
-class PeriodTests extends CatsSuite {
+class PeriodTests extends DisciplineSuite {
   // checkAll("Period", HashTests[Period].hash)
   // checkAll("Period", OrderTests[Period].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/YearMonthTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/YearMonthTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.YearMonth
-import io.chrisdavenport.cats.time.instances.yearmonth._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.yearmonth._
+import java.time.YearMonth
+import munit.DisciplineSuite
 
-class YearMonthTests extends CatsSuite {
+class YearMonthTests extends DisciplineSuite {
   checkAll("YearMonth", HashTests[YearMonth].hash)
   checkAll("YearMonth", OrderTests[YearMonth].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/YearTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/YearTests.scala
@@ -1,13 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.Year
-import io.chrisdavenport.cats.time.instances.year._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.year._
+import java.time.Year
+import munit.DisciplineSuite
 
-class YearTests extends CatsSuite {
+class YearTests extends DisciplineSuite {
   checkAll("Year", HashTests[Year].hash)
   checkAll("Year", OrderTests[Year].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneIdTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneIdTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
-import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.EqTests
-import java.time.ZoneId
-import io.chrisdavenport.cats.time.instances.zoneid._
+import cats.kernel.laws.discipline.HashTests
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.zoneid._
+import java.time.ZoneId
+import munit.DisciplineSuite
 
-class ZoneIdTests extends CatsSuite {
+class ZoneIdTests extends DisciplineSuite {
   checkAll("ZoneId", EqTests[ZoneId].eqv)
   checkAll("ZoneId", HashTests[ZoneId].hash)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneOffsetTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneOffsetTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.ZoneOffset
-import io.chrisdavenport.cats.time.instances.zoneoffset._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.zoneoffset._
+import java.time.ZoneOffset
+import munit.DisciplineSuite
 
-class ZoneOffsetTests extends CatsSuite {
+class ZoneOffsetTests extends DisciplineSuite {
   checkAll("ZoneOffset", HashTests[ZoneOffset].hash)
   checkAll("ZoneOffset", OrderTests[ZoneOffset].order)
 }

--- a/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZonedDateTimeTests.scala
+++ b/modules/tests/src/test/scala/io/chrisdavenport/cats/time/instances/ZonedDateTimeTests.scala
@@ -1,14 +1,13 @@
 package io.chrisdavenport.cats.time.instances
 
-
-import cats.tests.CatsSuite
 import cats.kernel.laws.discipline.HashTests
 import cats.kernel.laws.discipline.OrderTests
-import java.time.ZonedDateTime
-import io.chrisdavenport.cats.time.instances.zoneddatetime._
 import io.chrisdavenport.cats.time.arb.TimeArbitraries._
+import io.chrisdavenport.cats.time.instances.zoneddatetime._
+import java.time.ZonedDateTime
+import munit.DisciplineSuite
 
-class ZonedDateTimeTests extends CatsSuite {
+class ZonedDateTimeTests extends DisciplineSuite {
   checkAll("ZonedDateTime", HashTests[ZonedDateTime].hash)
   checkAll("ZonedDateTime", OrderTests[ZonedDateTime].order)
 }


### PR DESCRIPTION
This PR is aimed at the unification of a test framework in the `typelevel` organization.